### PR TITLE
WIP: Fix security

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Version: 0.26.0
 LazyData: TRUE
 Imports:
     base64enc,
+    digest,
     evaluate,
     httpuv,
     jsonlite,

--- a/R/host.R
+++ b/R/host.R
@@ -34,7 +34,16 @@ Host <- R6::R6Class("Host",
     #'
     #' Create a new \code{Host}
     initialize = function () {
-      private$.id <- paste(c('r-', sample(c(letters, 0:9), 64, replace=TRUE)), collapse="")
+      # Generate unique id. Note this currently only needs to be unique on the current machine
+      private$.id <- paste(
+        c('r-', sample(c(letters, 0:9), 64, replace=TRUE)),
+        collapse=''
+      )
+      # Generate secret to be used for authenticating requests
+      private$.secret <- paste(
+        sample(c(LETTERS, letters, 0:9, strsplit('~ ! @ # $ % ^ & * _ + - |', ' ')[[1]]), 256, replace=TRUE),
+        collapse=''
+      )
       private$.servers <- list()
       private$.instances <- list()
     },
@@ -138,6 +147,7 @@ Host <- R6::R6Class("Host",
       if (complete) {
         manifest <- c(manifest, list(
           id = private$.id,
+          secret = private$.secret,
           urls = self$urls,
           instances = names(private$.instances),
           environment = self$environment()
@@ -352,6 +362,7 @@ Host <- R6::R6Class("Host",
 
   private = list(
     .id = NULL,
+    .secret = NULL,
     .servers = NULL,
     .instances = NULL
   )

--- a/R/host.R
+++ b/R/host.R
@@ -344,6 +344,13 @@ Host <- R6::R6Class("Host",
       private$.id
     },
 
+    #' @section .secret:
+    #'
+    #' Get this host secret key
+    secret = function () {
+      private$.secret
+    },
+
     #' @section servers:
     #'
     #' Get a list of server names for this host. Servers are identified by the protocol shorthand


### PR DESCRIPTION
By default the `Host` listens on `127.0.0.1` which prevents malicious users accessing the host from outside of localhost. But a malicious user on localhost could execute code in a context being run by the current user. To prevent this the host should only accept connections from the current user - i.e. the one who started the host.